### PR TITLE
AlgorandAddress

### DIFF
--- a/ledger-core-algorand/inc/algorand/AlgorandAddress.hpp
+++ b/ledger-core-algorand/inc/algorand/AlgorandAddress.hpp
@@ -57,7 +57,7 @@ namespace core {
 
     private:
 
-        static const int32_t PUBKEY_LEN_BYTES = 36;
+        static const int32_t PUBKEY_LEN_BYTES = 32;
         static const int32_t CHECKSUM_LEN_BYTES = 4;
 
         std::string _address;

--- a/ledger-core-algorand/inc/algorand/AlgorandAddress.hpp
+++ b/ledger-core-algorand/inc/algorand/AlgorandAddress.hpp
@@ -39,13 +39,14 @@
 
 namespace ledger {
 namespace core {
+namespace algorand {
 
-    class AlgorandAddress : public Address {
+    class Address : public ledger::core::Address {
 
     public:
 
-        AlgorandAddress(const std::vector<uint8_t> & pubKey);
-        AlgorandAddress(const std::string & address);
+        Address(const std::vector<uint8_t> & pubKey);
+        Address(const std::string & address);
 
         std::string toString() override;
 
@@ -65,6 +66,7 @@ namespace core {
 
     };
 
+} // namespace algorand
 } // namespace core
 } // namespace ledger
 

--- a/ledger-core-algorand/inc/algorand/AlgorandAddress.hpp
+++ b/ledger-core-algorand/inc/algorand/AlgorandAddress.hpp
@@ -45,10 +45,11 @@ namespace core {
     public:
 
         AlgorandAddress(const std::vector<uint8_t> & pubKey);
+        AlgorandAddress(const std::string & address);
 
-        std::string toString() override ;
+        std::string toString() override;
 
-        std::vector<uint8_t> getPublicKey();
+        std::vector<uint8_t> getPublicKey() const;
 
         // Utility methods for easy conversion, could be useful for tests
         static std::string fromPublicKey(const std::vector<uint8_t> & pubKey);
@@ -56,6 +57,7 @@ namespace core {
 
     private:
 
+        static const int32_t PUBKEY_LEN_BYTES = 36;
         static const int32_t CHECKSUM_LEN_BYTES = 4;
 
         std::string _address;

--- a/ledger-core-algorand/inc/algorand/AlgorandAddress.hpp
+++ b/ledger-core-algorand/inc/algorand/AlgorandAddress.hpp
@@ -1,0 +1,69 @@
+/*
+ * AlgorandAddress
+ *
+ * Created by Hakim Aammar on 20/04/2020.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#ifndef LEDGER_CORE_ALGORANDADDRESS_H
+#define LEDGER_CORE_ALGORANDADDRESS_H
+
+#include <algorand/AlgorandLikeCurrencies.hpp>
+
+#include <core/address/Address.hpp>
+
+#include <string>
+#include <vector>
+
+namespace ledger {
+namespace core {
+
+    class AlgorandAddress : public Address {
+
+    public:
+
+        AlgorandAddress(const std::vector<uint8_t> & pubKey);
+
+        std::string toString() override ;
+
+        std::vector<uint8_t> getPublicKey();
+
+        // Utility methods for easy conversion, could be useful for tests
+        static std::string fromPublicKey(const std::vector<uint8_t> & pubKey);
+        static std::vector<uint8_t> toPublicKey(const std::string & address);
+
+    private:
+
+        static const int32_t CHECKSUM_LEN_BYTES = 4;
+
+        std::string _address;
+        std::vector<uint8_t> _publicKey;
+
+    };
+
+} // namespace core
+} // namespace ledger
+
+#endif // LEDGER_CORE_ALGORANDADDRESS_H

--- a/ledger-core-algorand/src/algorand/AlgorandAddress.cpp
+++ b/ledger-core-algorand/src/algorand/AlgorandAddress.cpp
@@ -46,11 +46,20 @@ namespace ledger {
             _address = AlgorandAddress::fromPublicKey(pubKey);
         }
 
+        AlgorandAddress::AlgorandAddress(const std::string & address) :
+            Address(
+                currencies::algorand(),
+                optional<std::string>("")),
+            _address(address)
+        {
+            _publicKey = AlgorandAddress::toPublicKey(address);
+        }
+
         std::string AlgorandAddress::toString() {
             return _address;
         }
 
-        std::vector<uint8_t> AlgorandAddress::getPublicKey() {
+        std::vector<uint8_t> AlgorandAddress::getPublicKey() const {
             return _publicKey;
         }
 
@@ -68,11 +77,13 @@ namespace ledger {
 
         // FIXME Test this
         std::vector<uint8_t> AlgorandAddress::toPublicKey(const std::string & address) {
-            std::vector<uint8_t> addressBytes;
+            std::vector<uint8_t> decoded;
+            decoded.reserve(PUBKEY_LEN_BYTES + CHECKSUM_LEN_BYTES);
             // 1. Decode from Base32
-            BaseConverter::decode(address, BaseConverter::BASE32_RFC4648_NO_PADDING, addressBytes);
-            // 2. Strip last 4 bytes
-            return std::vector<uint8_t>(addressBytes.cbegin(), addressBytes.cbegin() + addressBytes.size() - CHECKSUM_LEN_BYTES);
+            BaseConverter::decode(address, BaseConverter::BASE32_RFC4648_NO_PADDING, decoded);
+            // 2. Strip last 4 bytes to keep only the public key
+            decoded.resize(PUBKEY_LEN_BYTES);
+            return decoded;
         }
     }
 }

--- a/ledger-core-algorand/src/algorand/AlgorandAddress.cpp
+++ b/ledger-core-algorand/src/algorand/AlgorandAddress.cpp
@@ -35,55 +35,58 @@
 
 
 namespace ledger {
-    namespace core {
+namespace core {
+namespace algorand {
 
-        AlgorandAddress::AlgorandAddress(const std::vector<uint8_t> & pubKey) :
-            Address(
-                currencies::algorand(),
-                optional<std::string>("")),
-            _publicKey(pubKey)
-        {
-            _address = AlgorandAddress::fromPublicKey(pubKey);
-        }
-
-        AlgorandAddress::AlgorandAddress(const std::string & address) :
-            Address(
-                currencies::algorand(),
-                optional<std::string>("")),
-            _address(address)
-        {
-            _publicKey = AlgorandAddress::toPublicKey(address);
-        }
-
-        std::string AlgorandAddress::toString() {
-            return _address;
-        }
-
-        std::vector<uint8_t> AlgorandAddress::getPublicKey() const {
-            return _publicKey;
-        }
-
-        // FIXME Test this
-        std::string AlgorandAddress::fromPublicKey(const std::vector<uint8_t> & pubKey) {
-            // 1. pubkey --> pubKeyHash
-            const std::vector<uint8_t> pubKeyHash = SHA512256::bytesToBytesHash(pubKey);
-            // 2. 4 last bytes of pubKeyHash
-            const std::vector<uint8_t> pubKeyHashChecksum(pubKeyHash.cbegin() + pubKeyHash.size() - CHECKSUM_LEN_BYTES, pubKeyHash.cend());
-            // 3. pubkey + 4 last bytes of pubKeyHash
-            const std::vector<uint8_t> addressBytes = vector::concat<uint8_t>(pubKey, pubKeyHashChecksum);
-            // 4. Encode to Base32
-            return BaseConverter::encode(addressBytes, BaseConverter::BASE32_RFC4648_NO_PADDING);
-        }
-
-        // FIXME Test this
-        std::vector<uint8_t> AlgorandAddress::toPublicKey(const std::string & address) {
-            std::vector<uint8_t> decoded;
-            decoded.reserve(PUBKEY_LEN_BYTES + CHECKSUM_LEN_BYTES);
-            // 1. Decode from Base32
-            BaseConverter::decode(address, BaseConverter::BASE32_RFC4648_NO_PADDING, decoded);
-            // 2. Strip last 4 bytes to keep only the public key
-            decoded.resize(PUBKEY_LEN_BYTES);
-            return decoded;
-        }
+    Address::Address(const std::vector<uint8_t> & pubKey) :
+        Address(
+            currencies::algorand(),
+            optional<std::string>("")),
+        _publicKey(pubKey)
+    {
+        _address = Address::fromPublicKey(pubKey);
     }
-}
+
+    Address::Address(const std::string & address) :
+        Address(
+            currencies::algorand(),
+            optional<std::string>("")),
+        _address(address)
+    {
+        _publicKey = Address::toPublicKey(address);
+    }
+
+    std::string Address::toString() {
+        return _address;
+    }
+
+    std::vector<uint8_t> Address::getPublicKey() const {
+        return _publicKey;
+    }
+
+    // FIXME Test this
+    std::string Address::fromPublicKey(const std::vector<uint8_t> & pubKey) {
+        // 1. pubkey --> pubKeyHash
+        const std::vector<uint8_t> pubKeyHash = SHA512256::bytesToBytesHash(pubKey);
+        // 2. 4 last bytes of pubKeyHash
+        const std::vector<uint8_t> pubKeyHashChecksum(pubKeyHash.cbegin() + pubKeyHash.size() - CHECKSUM_LEN_BYTES, pubKeyHash.cend());
+        // 3. pubkey + 4 last bytes of pubKeyHash
+        const std::vector<uint8_t> addressBytes = vector::concat<uint8_t>(pubKey, pubKeyHashChecksum);
+        // 4. Encode to Base32
+        return BaseConverter::encode(addressBytes, BaseConverter::BASE32_RFC4648_NO_PADDING);
+    }
+
+    // FIXME Test this
+    std::vector<uint8_t> Address::toPublicKey(const std::string & address) {
+        std::vector<uint8_t> decoded;
+        decoded.reserve(PUBKEY_LEN_BYTES + CHECKSUM_LEN_BYTES);
+        // 1. Decode from Base32
+        BaseConverter::decode(address, BaseConverter::BASE32_RFC4648_NO_PADDING, decoded);
+        // 2. Strip last 4 bytes to keep only the public key
+        decoded.resize(PUBKEY_LEN_BYTES);
+        return decoded;
+    }
+    
+} // namespace algorand
+} // namespace core
+} // namespace ledger

--- a/ledger-core-algorand/src/algorand/AlgorandAddress.cpp
+++ b/ledger-core-algorand/src/algorand/AlgorandAddress.cpp
@@ -1,0 +1,78 @@
+/*
+ * AlgorandAddress
+ *
+ * Created by Hakim Aammar on 20/04/2020.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <algorand/AlgorandAddress.hpp>
+
+#include <core/collections/Vector.hpp>
+#include <core/crypto/SHA512256.hpp>
+#include <core/math/BaseConverter.hpp>
+
+
+namespace ledger {
+    namespace core {
+
+        AlgorandAddress::AlgorandAddress(const std::vector<uint8_t> & pubKey) :
+            Address(
+                currencies::algorand(),
+                optional<std::string>("")),
+            _publicKey(pubKey)
+        {
+            _address = AlgorandAddress::fromPublicKey(pubKey);
+        }
+
+        std::string AlgorandAddress::toString() {
+            return _address;
+        }
+
+        std::vector<uint8_t> AlgorandAddress::getPublicKey() {
+            return _publicKey;
+        }
+
+        // FIXME Test this
+        std::string AlgorandAddress::fromPublicKey(const std::vector<uint8_t> & pubKey) {
+            // 1. pubkey --> pubKeyHash
+            const std::vector<uint8_t> pubKeyHash = SHA512256::bytesToBytesHash(pubKey);
+            // 2. 4 last bytes of pubKeyHash
+            const std::vector<uint8_t> pubKeyHashChecksum(pubKeyHash.cbegin() + pubKeyHash.size() - CHECKSUM_LEN_BYTES, pubKeyHash.cend());
+            // 3. pubkey + 4 last bytes of pubKeyHash
+            const std::vector<uint8_t> addressBytes = vector::concat<uint8_t>(pubKey, pubKeyHashChecksum);
+            // 4. Encode to Base32
+            return BaseConverter::encode(addressBytes, BaseConverter::BASE32_RFC4648_NO_PADDING);
+        }
+
+        // FIXME Test this
+        std::vector<uint8_t> AlgorandAddress::toPublicKey(const std::string & address) {
+            std::vector<uint8_t> addressBytes;
+            // 1. Decode from Base32
+            BaseConverter::decode(address, BaseConverter::BASE32_RFC4648_NO_PADDING, addressBytes);
+            // 2. Strip last 4 bytes
+            return std::vector<uint8_t>(addressBytes.cbegin(), addressBytes.cbegin() + addressBytes.size() - CHECKSUM_LEN_BYTES);
+        }
+    }
+}

--- a/ledger-core/inc/core/crypto/SHA512256.hpp
+++ b/ledger-core/inc/core/crypto/SHA512256.hpp
@@ -1,0 +1,48 @@
+/*
+ * SHA512256
+ *
+ * Created by Hakim Aammar on 20/04/2020.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace ledger {
+    namespace core {
+        class SHA512256 {
+        public:
+            static std::string stringToHexHash(const std::string& input);
+            static std::string bytesToHexHash(const std::vector<uint8_t>& bytes);
+            static std::vector<uint8_t> stringToBytesHash(const std::string& input);
+            static std::vector<uint8_t> bytesToBytesHash(const std::vector<uint8_t>& bytes);
+
+        private:
+            static std::vector<uint8_t> dataToBytesHash(const void *data, size_t size);
+        };
+    }
+}

--- a/ledger-core/src/core/crypto/SHA512256.cpp
+++ b/ledger-core/src/core/crypto/SHA512256.cpp
@@ -1,0 +1,73 @@
+/*
+ * SHA512256
+ *
+ * Created by Hakim Aammar on 20/04/2020.
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Ledger
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+
+#include <core/crypto/SHA512256.hpp>
+#include <core/utils/Hex.hpp>
+
+#include <openssl/sha.h>
+
+namespace ledger {
+    namespace core {
+        std::string SHA512256::stringToHexHash(const std::string &input) {
+            return hex::toString(stringToBytesHash(input));
+        }
+
+        std::string SHA512256::bytesToHexHash(const std::vector<uint8_t> &bytes) {
+            return hex::toString(bytesToBytesHash(bytes));
+        }
+
+        std::vector<uint8_t> SHA512256::dataToBytesHash(const void *data, size_t size) {
+            /*
+            // FIXME Use SHA-512/256 instead of SHA-512
+            uint8_t hash[SHA512256_DIGEST_LENGTH];
+            SHA512256_CTX sha512;
+            SHA512256_Init(&sha512);
+            SHA512256_Update(&sha512, data, size);
+            SHA512256_Final(hash, &sha512);
+            return std::vector<uint8_t >(hash, hash + SHA512_DIGEST_LENGTH);
+            /*/
+            uint8_t hash[SHA512_DIGEST_LENGTH];
+            SHA512_CTX sha512;
+            SHA512_Init(&sha512);
+            SHA512_Update(&sha512, data, size);
+            SHA512_Final(hash, &sha512);
+            return std::vector<uint8_t >(hash, hash + SHA512_DIGEST_LENGTH);
+            //*/
+        }
+
+        std::vector<uint8_t> SHA512256::stringToBytesHash(const std::string &input) {
+            return dataToBytesHash(input.c_str(), input.size());
+        }
+
+        std::vector<uint8_t> SHA512256::bytesToBytesHash(const std::vector<uint8_t> &bytes) {
+            return dataToBytesHash(bytes.data(), bytes.size());
+        }
+    }
+}


### PR DESCRIPTION
Implementation of AlgorandAddress, based on temporary (incorrect) implementation of SHA-512/256 wrapper.

I also put the wrapper part on a separate clean branch based on design/modularization, to send a PR to libcore when it's ready. I copy the modifications here so that we can keep moving while it's not merged in libcore yet.