### PR TITLE
Also retrieve latest block during Algorand synchro

### DIFF
--- a/core/src/wallet/algorand/AlgorandAccountSynchronizer.cpp
+++ b/core/src/wallet/algorand/AlgorandAccountSynchronizer.cpp
@@ -41,8 +41,6 @@
 #include <api/Configuration.hpp>
 #include <api/ConfigurationDefaults.hpp>
 
-#include <iostream>
-
 
 namespace ledger {
 namespace core {

--- a/core/src/wallet/algorand/AlgorandAccountSynchronizer.cpp
+++ b/core/src/wallet/algorand/AlgorandAccountSynchronizer.cpp
@@ -37,9 +37,12 @@
 #include "utils/Exception.hpp"
 #include <collections/vector.hpp>
 #include <debug/Benchmarker.h>
+#include <async/Future.hpp>
 #include <api/Configuration.hpp>
 #include <api/ConfigurationDefaults.hpp>
+
 #include <iostream>
+
 
 namespace ledger {
 namespace core {
@@ -89,8 +92,10 @@ namespace algorand {
             _internalPreferences->editor()->template putObject<SavedState>("state", savedState.getValue())->commit();
         }
 
-        return synchronizeBatch(account, false, firstRound)
-            .template flatMap<Unit>(account->getContext(), [] (const bool hadTransactions) -> Future<Unit> {
+        return updateLatestBlock(account->getContext())
+            .template flatMap<bool>(account->getContext(), [this, account, firstRound] (const Unit&) -> Future<bool> {
+                return synchronizeBatch(account, false, firstRound);
+            }).template flatMap<Unit>(account->getContext(), [] (const bool hadTransactions) -> Future<Unit> {
                 return Future<Unit>::successful(unit);
             }).recoverWith(ImmediateExecutionContext::INSTANCE, [] (const Exception & exception) -> Future<Unit> {
                 return Future<Unit>::failure(exception);
@@ -136,6 +141,25 @@ namespace algorand {
                     return synchronizeBatch(account, hadTX, lowestRound, lowestBatchRound);
                 } else {
                     return Future<bool>::successful(hadTX);
+                }
+            });
+    }
+
+    Future<Unit> AccountSynchronizer::updateLatestBlock(const std::shared_ptr<api::ExecutionContext> &context) {
+        return _explorer->getLatestBlock()
+            .template flatMap<Unit>(context, [this] (const Try<api::Block>& block) -> Future<Unit> {
+                if (block.isSuccess()) {
+                    soci::session sql(_account->getWallet()->getDatabase()->getPool());
+                    soci::transaction tr(sql);
+                    try {
+                        auto blockRef = const_cast<api::Block&>(block.getValue());
+                        blockRef.currencyName = _account->getWallet()->getCurrency().name;
+                        _account->putBlock(sql, blockRef);
+                        tr.commit();
+                    } catch(...) {
+                        tr.rollback();
+                    }
+                    return Future<Unit>::successful(unit);
                 }
             });
     }

--- a/core/src/wallet/algorand/AlgorandAccountSynchronizer.hpp
+++ b/core/src/wallet/algorand/AlgorandAccountSynchronizer.hpp
@@ -79,6 +79,8 @@ namespace algorand {
                                       const Option<uint64_t> & lowestRound = Option<uint64_t>(),
                                       const Option<uint64_t> & highestRound = Option<uint64_t>());
 
+        Future<Unit> updateLatestBlock(const std::shared_ptr<api::ExecutionContext> &context);
+
         std::shared_ptr<Account> _account;
         std::shared_ptr<BlockchainExplorer> _explorer;
         std::shared_ptr<Preferences> _internalPreferences;

--- a/core/src/wallet/algorand/AlgorandBlockchainExplorer.cpp
+++ b/core/src/wallet/algorand/AlgorandBlockchainExplorer.cpp
@@ -56,23 +56,29 @@ namespace algorand {
         return _http->GET(fmt::format(constants::purestakeBlockEndpoint, blockHeight))
             .json(false)
             .map<api::Block>(getContext(), [](const HttpRequest::JsonResult& response) {
-                    const auto& json = std::get<1>(response)->GetObject();
-                    auto block = api::Block();
-                    JsonParser::parseBlock(json, block);
-                    return block;
+                const auto& json = std::get<1>(response)->GetObject();
+                auto block = api::Block();
+                JsonParser::parseBlock(json, block);
+                return block;
             });
-            /*// NOTE: In case we actually need to retrieve blocks for each tx... (untested!)
-            // Add block information to the transaction
-            .template flatMap<model::Transaction>(getContext(), [this](const model::Transaction &tx) -> Future<model::Transaction> {
-                auto output = model::Transaction(tx);
-                return getBlock(tx.header.round.getValue())
-                    .map<model::Transaction>(getContext(), [output](const api::Block &block) mutable {
-                        output.header.block = block;
-                        return output;
-                    });
-            });
-            */
     }
+
+    Future<api::Block> BlockchainExplorer::getLatestBlock() const
+    {
+        // The Algorand API doesn't have a "latest block" endpoint,
+        // so we need to retrieve the latest round number first,
+        // then retrieve the associated block
+        return _http->GET(fmt::format(constants::purestakeStatusEndpoint))
+            .json(true)
+            .map<uint64_t>(getContext(), [](const HttpRequest::JsonResult &response) {
+                    const auto &json = std::get<1>(response)->GetObject();
+                    return std::stoull(json[constants::xLastRoundParam.c_str()].GetString());
+                })
+            .template flatMap<api::Block>(getContext(), [this](const uint64_t& latestRound) -> Future<api::Block> {
+                return getBlock(latestRound);
+            });
+    }
+
 
     Future<model::Account> BlockchainExplorer::getAccount(const std::string& address) const
     {
@@ -137,36 +143,6 @@ namespace algorand {
                     txs.hasNext = txs.transactions.size() >= constants::EXPLORER_QUERY_LIMIT;
                     return txs;
             });
-            /*// NOTE: In case we actually need to retrieve blocks for each tx... (untested!)
-            .template flatMap<model::TransactionsBulk>(getContext(), [this](const model::TransactionsBulk & txs) -> Future<model::TransactionsBulk> {
-                // - build set of (unique) blockHeights to fetch
-                const auto blockHeights = vector::map<uint64_t, model::Transaction>(txs.transactions,
-                    [](const model::Transaction& tx) {
-                        return tx.header.round.getValue();
-                    });
-                const std::unordered_set<uint64_t> uniqueBlockHeights(blockHeights.begin(), blockHeights.end());
-                // - build vector of promises for each block
-                std::vector<Future<api::Block>> blockPromises;
-                for (auto blockHeight : uniqueBlockHeights) {
-                    blockPromises.push_back(getBlock(blockHeight));
-                }
-                // - async::sequence
-                return async::sequence(getContext(), blockPromises)
-                    .flatMap<model::TransactionsBulk>(getContext(), [&txs](const std::vector<api::Block> & blocks) {
-                        // - build map of <blockHeight, api::Block> ?
-                        //auto blockPerHeight = std::unordered_map<uint64_t, api::Block>();
-                        auto txsMutable = const_cast<model::TransactionsBulk &>(txs);
-                        for (auto& tx : txsMutable.transactions) {
-                            for (const auto& block : blocks) {
-                                if (tx.header.round.getValue() == block.height) {
-                                    tx.header.block = block;
-                                }
-                            }
-                        }
-                        return Future<model::TransactionsBulk>::successful(txsMutable);
-                    });
-            });
-            */
     }
 
     Future<model::TransactionParams> BlockchainExplorer::getTransactionParams() const

--- a/core/src/wallet/algorand/AlgorandBlockchainExplorer.cpp
+++ b/core/src/wallet/algorand/AlgorandBlockchainExplorer.cpp
@@ -68,7 +68,7 @@ namespace algorand {
         // The Algorand API doesn't have a "latest block" endpoint,
         // so we need to retrieve the latest round number first,
         // then retrieve the associated block
-        return _http->GET(fmt::format(constants::purestakeStatusEndpoint))
+        return _http->GET(constants::purestakeStatusEndpoint)
             .json(true)
             .map<uint64_t>(getContext(), [](const HttpRequest::JsonResult &response) {
                     const auto &json = std::get<1>(response)->GetObject();

--- a/core/src/wallet/algorand/AlgorandBlockchainExplorer.hpp
+++ b/core/src/wallet/algorand/AlgorandBlockchainExplorer.hpp
@@ -48,6 +48,7 @@ namespace constants {
     static const std::string purestakeTokenHeader = "x-api-key";
 
     // Explorer endpoints
+    static const std::string purestakeStatusEndpoint = "/status";
     static const std::string purestakeBlockEndpoint = "/block/{}";
     static const std::string purestakeAccountEndpoint = "/account/{}";
     static const std::string purestakeAccountTransactionsEndpoint = "/account/{}/transactions";
@@ -69,6 +70,8 @@ namespace constants {
                            const std::shared_ptr<api::DynamicObject> & configuration);
 
         Future<api::Block> getBlock(uint64_t blockHeight) const;
+
+        Future<api::Block> getLatestBlock() const;
 
         Future<model::Account> getAccount(const std::string & address) const;
 

--- a/core/test/algorand/AlgorandExplorerTests.cpp
+++ b/core/test/algorand/AlgorandExplorerTests.cpp
@@ -58,7 +58,6 @@ public:
     std::shared_ptr<BlockchainExplorer> explorer;
 };
 
-
 TEST_F(AlgorandExplorerTest, GetBlock) {
 
     uint64_t blockHeight = 6000000; // Some arbitrary block
@@ -69,6 +68,15 @@ TEST_F(AlgorandExplorerTest, GetBlock) {
     EXPECT_EQ(block.height, blockHeight);
     EXPECT_EQ(block.blockHash, "SWM7OIULX7F7KMGZSGU54FCEVVVCV6XWT6CEG7EH7WI4LHWHNB7A");
     EXPECT_EQ(block.time, blockTime);
+}
+
+TEST_F(AlgorandExplorerTest, GetLatestBlock) {
+
+    api::Block block = ::wait(explorer->getLatestBlock());
+
+    EXPECT_FALSE(block.blockHash.empty());
+    EXPECT_GT(block.height, 7000000);
+    EXPECT_GT(block.time.time_since_epoch().count(), 1593455156000000000);
 }
 
 TEST_F(AlgorandExplorerTest, GetAccount) {

--- a/core/test/algorand/AlgorandSynchronizationTests.cpp
+++ b/core/test/algorand/AlgorandSynchronizationTests.cpp
@@ -46,52 +46,75 @@ using namespace ledger::testing::algorand;
 using namespace ledger::core::algorand;
 
 class AlgorandSynchronizationTest : public WalletFixture<WalletFactory> {
+public:
+    void SetUp() override {
+        WalletFixture::SetUp();
+        backend->enableQueryLogging(true);
+    }
+
+    void synchronizeAccount(const std::string & accountAddress) {
+        registerCurrency(currencies::ALGORAND);
+
+        auto configuration = DynamicObject::newInstance();
+        configuration->putString(api::Configuration::KEYCHAIN_DERIVATION_SCHEME,"44'/<coin_type>'/<account>'/<node>'/<address>");
+        configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_ENGINE, api::AlgorandBlockchainExplorerEngines::ALGORAND_NODE);
+        configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_API_ENDPOINT, api::AlgorandConfigurationDefaults::ALGORAND_API_ENDPOINT);
+
+        auto wallet = std::dynamic_pointer_cast<Wallet>(wait(pool->createWallet("test-wallet", "algorand", configuration)));
+
+        auto nextIndex = wait(wallet->getNextAccountIndex());
+        EXPECT_EQ(nextIndex, 0);
+
+        const api::AccountCreationInfo info(
+            nextIndex,
+            {"main"},
+            {"44'/283'/0'/0'"},
+            { algorand::Address::toPublicKey(accountAddress) },
+            {hex::toByteArray("")}
+        );
+
+        _account = std::dynamic_pointer_cast<Account>(wait(wallet->newAccountWithInfo(info)));
+
+        auto receiver = make_receiver([=](const std::shared_ptr<api::Event> &event) {
+            fmt::print("Received event {}\n", api::to_string(event->getCode()));
+
+            if (event->getCode() == api::EventCode::SYNCHRONIZATION_STARTED) {
+                return;
+            }
+            EXPECT_EQ(event->getCode(), api::EventCode::SYNCHRONIZATION_SUCCEED);
+
+            dispatcher->stop();
+        });
+
+        _account->synchronize()->subscribe(dispatcher->getMainExecutionContext(), receiver);
+        dispatcher->waitUntilStopped();
+    }
+
+    std::shared_ptr<Account> _account;
+
 };
 
+TEST_F(AlgorandSynchronizationTest, EmptyAccountSynchronizationTest) {
+    synchronizeAccount(EMPTY_ADDRESS);
+
+    // Simulate the getLastBlock that Live does after an account sync
+    // Just check nothing goes wrong
+    EXPECT_NO_THROW(wait(pool->getLastBlock(currencies::ALGORAND.name)));
+
+    auto operations = wait(std::dynamic_pointer_cast<OperationQuery>(_account->queryOperations()->complete())->execute());
+    EXPECT_EQ(operations.size(), 0);
+
+}
+
 TEST_F(AlgorandSynchronizationTest, AccountSynchronizationTest) {
-    backend->enableQueryLogging(true);
-    registerCurrency(currencies::ALGORAND);
+    synchronizeAccount(OBELIX_ADDRESS);
 
-    auto configuration = DynamicObject::newInstance();
-    configuration->putString(api::Configuration::KEYCHAIN_DERIVATION_SCHEME,"44'/<coin_type>'/<account>'/<node>'/<address>");
-    configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_ENGINE, api::AlgorandBlockchainExplorerEngines::ALGORAND_NODE);
-    configuration->putString(api::Configuration::BLOCKCHAIN_EXPLORER_API_ENDPOINT, api::AlgorandConfigurationDefaults::ALGORAND_API_ENDPOINT);
-
-    auto wallet = std::dynamic_pointer_cast<Wallet>(wait(pool->createWallet("test-wallet", "algorand", configuration)));
-
-    auto nextIndex = wait(wallet->getNextAccountIndex());
-    EXPECT_EQ(nextIndex, 0);
-
-    const api::AccountCreationInfo info(
-        nextIndex,
-        {"main"},
-        {"44'/283'/0'/0'"},
-        { algorand::Address::toPublicKey(OBELIX_ADDRESS) },
-        {hex::toByteArray("")}
-    );
-
-    auto account = std::dynamic_pointer_cast<Account>(wait(wallet->newAccountWithInfo(info)));
-    auto internalPreferences = account->getInternalPreferences()->getSubPreferences("AlgorandAccountSynchronizer");
-
-    auto receiver = make_receiver([=](const std::shared_ptr<api::Event> &event) {
-        fmt::print("Received event {}\n", api::to_string(event->getCode()));
-
-        if (event->getCode() == api::EventCode::SYNCHRONIZATION_STARTED) {
-            return;
-        }
-        EXPECT_EQ(event->getCode(), api::EventCode::SYNCHRONIZATION_SUCCEED);
-
-        dispatcher->stop();
-    });
-
-    account->synchronize()->subscribe(dispatcher->getMainExecutionContext(), receiver);
-    dispatcher->waitUntilStopped();
-
+    auto internalPreferences = _account->getInternalPreferences()->getSubPreferences("AlgorandAccountSynchronizer");
     auto savedState = internalPreferences->template getObject<SavedState>("state");
     std::cout << ">>> Saved block round for next synchronization: " << savedState.getValue().round << std::endl;
     EXPECT_GT(savedState.getValue().round, 6000000);
 
-    auto operations = wait(std::dynamic_pointer_cast<OperationQuery>(account->queryOperations()->complete())->execute());
+    auto operations = wait(std::dynamic_pointer_cast<OperationQuery>(_account->queryOperations()->complete())->execute());
     std::cout << ">>> Nb of operations: " << operations.size() << std::endl;
     EXPECT_GT(operations.size(), 200);
 }

--- a/core/test/algorand/AlgorandTestFixtures.hpp
+++ b/core/test/algorand/AlgorandTestFixtures.hpp
@@ -49,6 +49,7 @@ namespace algorand {
     using ledger::core::BaseConverter;
     using ledger::core::Option;
 
+    static const std::string EMPTY_ADDRESS = "RB7DUHGKVT3C3NEKP6255KPJDOKLMNXKADZA5UVWVS4YHDDVXYEDHGJKU4"; // This address should be unused and have 0 tx
     static const std::string OBELIX_ADDRESS = "RGX5XA7DWZOZ5SLG4WQSNIFKIG4CNX4VOH23YCEX56523DQEAL3QL56XZM";
     static const std::string TEST_ACCOUNT_ADDRESS = "6ENXFMQRRIF6KD7HXE47HUHCJXEUKGGRGR6LXSX7RRZBTMVI5NUDOQDTNE";
 


### PR DESCRIPTION
During a multi-account synchronization, Ledger Live wants to obtain the latest block of the blockchain.
This was not retrieved during Algorand synchronization, this PR fixes that.